### PR TITLE
Gracefully handle malformed signatures

### DIFF
--- a/lib/http_signatures/verification.rb
+++ b/lib/http_signatures/verification.rb
@@ -18,6 +18,8 @@ module HttpSignatures
 
     def signature_matches?
       expected_signature_base64 == provided_signature_base64
+    rescue SignatureParametersParser::Error
+      false
     end
 
     def expected_signature_base64

--- a/spec/verifier_spec.rb
+++ b/spec/verifier_spec.rb
@@ -44,4 +44,9 @@ RSpec.describe HttpSignatures::Verifier do
     expect(verifier.valid?(message)).to eq(false)
   end
 
+  it "rejects message with malformed signature" do
+    message["Signature"] = "foo=bar,baz=bla,yadda=yadda"
+    expect(verifier.valid?(message)).to eq(false)
+  end
+
 end


### PR DESCRIPTION
Swallow errors when the signature header cannot be parsed.