### PR TITLE
Implement External KeyStore Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ $context = HttpSignatures::Context.new(
 If there's only one key in the `keys` hash, that will be used for signing.
 Otherwise, specify one via `signing_key_id: "examplekey"`.
 
+`keys` may be an instance of `HttpSignature::KeyStore` or other object
+that conforms to its API.
+
 ### Messages
 
 A message is an HTTP request or response. A subset of the interface of

--- a/lib/http_signatures/context.rb
+++ b/lib/http_signatures/context.rb
@@ -2,7 +2,7 @@ module HttpSignatures
   class Context
 
     def initialize(keys: {}, signing_key_id: nil, algorithm: nil, headers: nil)
-      @key_store = KeyStore.new(keys)
+      @key_store = keys.is_a?(KeyStore) ? keys : KeyStore.new(keys)
       @signing_key_id = signing_key_id
       @algorithm_name = algorithm
       @headers = headers

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -61,4 +61,28 @@ RSpec.describe HttpSignatures::Context do
     end
   end
 
+  context "external KeyStore" do
+    ExternalKeyStore = Class.new(HttpSignatures::KeyStore)
+    subject(:context) do
+      HttpSignatures::Context.new(
+        keys: ExternalKeyStore.new({"hello" => "world", "another" => "key"}),
+        signing_key_id: "another",
+        algorithm: "hmac-sha256",
+        headers: %w{(request-target) date content-length},
+      )
+    end
+
+    describe "@key_store" do
+      it "intantiates with the passed-in KeyStore" do
+        expect(context.instance_variable_get(:@key_store)).to be_a(ExternalKeyStore)
+      end
+    end
+
+    describe "#signer" do
+      it "signs without errors" do
+        context.signer.sign(message)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
The `keys` option in `Context` may may be an instance of
`HttpSignature::KeyStore` or other object
that conforms to its API.