### PR TITLE
Use `Time#httpdate` instead of `Time#rfc822`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ require "time"
 
 message = Net::HTTP::Get.new(
   "/path?query=123",
-  "Date" => Time.now.rfc822,
+  "Date" => Time.now.httpdate,
   "Content-Length" => "0",
 )
 ```


### PR DESCRIPTION
Hi, thank you for making useful gem :) 

I've made a tiny update for README.md.

`Time#rfc822` (alias of `Time#rfc2822`) represents time zone as `[+-]hhmm` format.
While `Time#httpdate` represents time zone as `GMT` always, which is preferable as HTTP Date header format.

example:

```ruby
irb(main):001:0> require 'time'
=> true
irb(main):002:0> Time.now.rfc822
=> "Mon, 10 Aug 2020 17:03:58 +0900"
irb(main):003:0> Time.now.httpdate
=> "Mon, 10 Aug 2020 08:04:02 GMT"
```

references:

- https://tools.ietf.org/html/rfc2616#section-3.3
- https://tools.ietf.org/html/rfc7231#section-7.1.1.2
- https://ruby-doc.org/stdlib-2.7.1/libdoc/time/rdoc/Time.html#method-i-httpdate
- https://ruby-doc.org/stdlib-2.7.1/libdoc/time/rdoc/Time.html#method-i-rfc2822